### PR TITLE
Update branch name

### DIFF
--- a/Beacon.def
+++ b/Beacon.def
@@ -12,8 +12,8 @@ From: ubuntu:22.04
     apt -y install git
     
     # Clone git
-    git clone https://gitlab.bsc.es/impact-data/impd-beacon_cbioportal.git --branch RI-implementation ./RI-implementation
-    cd RI-implementation
+    git clone https://gitlab.bsc.es/impact-data/impd-beacon_cbioportal.git
+    cd impd-beacon_cbioportal
     apt install python3-venv -y
     cd beacon2-ri-api/
     
@@ -65,13 +65,13 @@ org_info = ""' > conf.py
     
     
 %environment
-    export PATH=$PATH:/RI-implementation/beacon2-ri-api/.pycBioPortalenv/bin/pip
+    export PATH=$PATH:/impd-beacon_cbioportal/beacon2-ri-api/.pycBioPortalenv/bin/pip
 
 %runscript
     #!/bin/bash
 
     # Predefined values
-    cd /RI-implementation/beacon2-ri-api
+    cd /impd-beacon_cbioportal/beacon2-ri-api
     cBioPortal_URL="https://www.cbioportal.org/api"
     study_name="acc_tcga"
     

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ http://localhost:5050/api/map
 http://localhost:5050/api/configuration
 ```
 
-More information about implementation and usage: https://gitlab.bsc.es/impact-data/impd-beacon_cbioportal/-/tree/RI-implementation/ 
+More information about implementation and usage: https://gitlab.bsc.es/impact-data/impd-beacon_cbioportal
 
 
 


### PR DESCRIPTION
I've removed the RI-Implementation branch in the [repo](https://gitlab.bsc.es/impact-data/impd-beacon_cbioportal). Now, the development in RI-Implementation is the `main` branch. So, from `Beacon.def` I've changed the urls going to the RI-Implementation branch to the main one.